### PR TITLE
remove-hardcoded-node & pnpm versions

### DIFF
--- a/.github/workflows/typescript-autodocs.yml
+++ b/.github/workflows/typescript-autodocs.yml
@@ -14,12 +14,6 @@ on:
         default: "10.4.1"
         required: false
 
-      docs-script:
-        type: string
-        default: "generate-docs"
-        required: false
-
-
 jobs:
   autodocs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes: #5 

This change updates the AutoDocs reusable GitHub Actions workflow to make the pnpm version configurable via workflow_call inputs, with a default fallback to 10.4.1. This allows consuming repositories to override the pnpm version when needed.