### PR TITLE
fix: remove GITHUB_TOKEN from workflow_call secrets

### DIFF
--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -2,9 +2,6 @@ name: PR Target Workflow
 
 on:
   workflow_call:
-    secrets:
-      GITHUB_TOKEN:
-        required: true
   
   # Direct trigger for this repository
   pull_request_target:


### PR DESCRIPTION
Fixes workflow error in `pull-request-target.yml` 

**Error:** https://github.com/PalisadoesFoundation/.github/actions/runs/20677555661

**Cause:** `GITHUB_TOKEN` cannot be declared in `workflow_call` secrets (it's auto-available).

**Fix:** Removed lines 5-7. Token still works on line 58.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to streamline secret handling processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->