### PR TITLE
Fix: Remove GITHUB_TOKEN from workflow_call secrets in issue workflows

### DIFF
--- a/.github/workflows/issue-unassigned.yml
+++ b/.github/workflows/issue-unassigned.yml
@@ -2,9 +2,6 @@ name: Add Unapproved Label on Unassignment (Reusable)
 
 on:
   workflow_call:
-    secrets:
-      GITHUB_TOKEN:
-        required: true
   
   # Direct trigger for this repository
   issues:

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -2,9 +2,6 @@ name: Issue Auto Label (Reusable)
 
 on:
   workflow_call:
-    secrets:
-      GITHUB_TOKEN:
-        required: true
   
   # Direct trigger for this repository
   issues:


### PR DESCRIPTION
Fixes #18 
Fixes remaining GITHUB_TOKEN errors in workflow files in `issue.yml ` and `issue-unassigned.yml `

**Cause:** `GITHUB_TOKEN` cannot be declared in `workflow_call` secrets (it's auto-available).

**Fix**: Removed lines 5-7 from both files. Token still works where used.
