### PR TITLE
Add stale unassign GitHub Action

### DIFF
--- a/.github/actions/stale-unassign/action.yml
+++ b/.github/actions/stale-unassign/action.yml
@@ -15,8 +15,8 @@ inputs:
     description: 'Run without making changes. Logs intended actions.'
     required: false
     default: 'false'
-  stale-label:
-    description: 'Label that marks issues as stale'
+  exclusion-labels:
+    description: 'Comma-separated list of labels that mark issues for exclusion (e.g., "no-issue-activity,on-hold,waiting-for-maintainer")'
     required: false
     default: 'no-issue-activity'
   comment-message:
@@ -41,7 +41,7 @@ runs:
       env:
         GRACE_PERIOD_DAYS: ${{ inputs.grace-period-days }}
         GRACE_PERIOD_MINUTES: ${{ inputs.grace-period-minutes }}
-        STALE_LABEL: ${{ inputs.stale-label }}
+        EXCLUSION_LABELS: ${{ inputs.exclusion-labels }}
         COMMENT_TEMPLATE: ${{ inputs.comment-message }}
         MAX_ISSUES_PER_RUN: ${{ inputs.max-issues-per-run }}
         DRY_RUN: ${{ inputs.dry-run }}
@@ -125,7 +125,7 @@ runs:
             gracePeriodDisplay = `${gracePeriodDays} days`;
           }
 
-          const staleLabel = process.env.STALE_LABEL;
+          const exclusionLabelsInput = process.env.EXCLUSION_LABELS;
           const commentTemplate = process.env.COMMENT_TEMPLATE;
           const dryRun = process.env.DRY_RUN === 'true';
 
@@ -135,9 +135,19 @@ runs:
             maxIssuesPerRun = DEFAULT_MAX_ISSUES;
           }
 
-          // Validate stale-label is non-empty
-          if (!staleLabel || staleLabel.trim() === '') {
-            console.error('Error: stale-label input is empty. Cannot proceed.');
+          // Parse and validate exclusion labels
+          if (!exclusionLabelsInput || exclusionLabelsInput.trim() === '') {
+            console.error('Error: exclusion-labels input is empty. Cannot proceed.');
+            return;
+          }
+          
+          const exclusionLabels = exclusionLabelsInput
+            .split(',')
+            .map(label => label.trim())
+            .filter(label => label.length > 0);
+          
+          if (exclusionLabels.length === 0) {
+            console.error('Error: No valid exclusion labels found after parsing. Cannot proceed.');
             return;
           }
 
@@ -146,7 +156,7 @@ runs:
             console.warn('Warning: comment-message does not contain {assignee} placeholder. Unassigned users will not be mentioned.');
           }
 
-          console.log(`Configuration: grace-period=${gracePeriodDisplay}, stale-label="${staleLabel}", max-issues=${maxIssuesPerRun || 'unlimited'}, dry-run=${dryRun}`);
+          console.log(`Configuration: grace-period=${gracePeriodDisplay}, exclusion-labels="${exclusionLabels.join(', ')}", max-issues=${maxIssuesPerRun || 'unlimited'}, dry-run=${dryRun}`);
 
           // Check if repository is archived
           const { data: repo } = await retry(() => github.rest.repos.get({
@@ -159,29 +169,40 @@ runs:
             return;
           }
 
-          // Check if the stale label exists in this repository
-          try {
-            await retry(() => github.rest.issues.getLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: staleLabel
-            }));
-          } catch (error) {
-            if (error.status === 404) {
-              console.log(`Label "${staleLabel}" does not exist in this repository. Skipping.`);
-              return;
+          // Check if at least one exclusion label exists in this repository
+          let validExclusionLabels = [];
+          for (const label of exclusionLabels) {
+            try {
+              await retry(() => github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label
+              }));
+              validExclusionLabels.push(label);
+            } catch (error) {
+              if (error.status === 404) {
+                console.warn(`Label "${label}" does not exist in this repository, skipping this label.`);
+              } else {
+                throw error;
+              }
             }
-            throw error;
           }
+          
+          if (validExclusionLabels.length === 0) {
+            console.log('None of the exclusion labels exist in this repository. Skipping.');
+            return;
+          }
+          
+          console.log(`Using ${validExclusionLabels.length} valid exclusion label(s): ${validExclusionLabels.join(', ')}`);
 
-          // Find open issues with stale label
-          let issues = [];
+
+          // Find all open issues in the repository
+          let allIssues = [];
           try {
-            issues = await retry(() => github.paginate(github.rest.issues.listForRepo, {
+            allIssues = await retry(() => github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
-              labels: staleLabel,
               per_page: 100
             }));
           } catch (error) {
@@ -189,7 +210,14 @@ runs:
             throw error;
           }
 
-          console.log(`Found ${issues.length} open issues with "${staleLabel}" label`);
+          // Filter issues that have ANY of the exclusion labels
+          const issues = allIssues.filter(issue => {
+            const issueLabels = issue.labels.map(l => l.name);
+            return validExclusionLabels.some(label => issueLabels.includes(label));
+          });
+
+          console.log(`Found ${issues.length} open issues with any of the exclusion labels: ${validExclusionLabels.join(', ')}`);
+
 
           // Apply max issues limit if set
           if (maxIssuesPerRun > 0 && issues.length > maxIssuesPerRun) {
@@ -274,14 +302,14 @@ runs:
 
               console.log(`Issue #${issue.number}: No open linked PR found, checking grace period...`);
 
-              // Find when stale label was added (get the most recent one in case of re-labeling)
+              // Find when any exclusion label was added (get the most recent one)
               const labelEvents = timelineEvents.filter(event =>
                 event.event === 'labeled' &&
-                event.label?.name === staleLabel
+                validExclusionLabels.includes(event.label?.name)
               );
 
               if (labelEvents.length === 0) {
-                console.log(`Issue #${issue.number}: Could not find label event in timeline, skipping`);
+                console.log(`Issue #${issue.number}: Could not find any exclusion label event in timeline, skipping`);
                 skippedCount++;
                 continue;
               }

--- a/.github/actions/stale-unassign/action.yml
+++ b/.github/actions/stale-unassign/action.yml
@@ -15,10 +15,14 @@ inputs:
     description: 'Run without making changes. Logs intended actions.'
     required: false
     default: 'false'
-  exclusion-labels:
-    description: 'Comma-separated list of labels that mark issues for exclusion (e.g., "no-issue-activity,on-hold,waiting-for-maintainer")'
+  stale-label:
+    description: 'Label that triggers unassignment countdown (e.g., "no-issue-activity")'
     required: false
     default: 'no-issue-activity'
+  exclusion-labels:
+    description: 'Comma-separated labels that PREVENT unassignment even if stale-label is present (e.g., "waiting-for-maintainer,blocked"). Leave empty for no exclusions.'
+    required: false
+    default: ''
   comment-message:
     description: 'Comment posted when assignee is removed. Use {assignee} placeholder for username.'
     required: false
@@ -41,6 +45,7 @@ runs:
       env:
         GRACE_PERIOD_DAYS: ${{ inputs.grace-period-days }}
         GRACE_PERIOD_MINUTES: ${{ inputs.grace-period-minutes }}
+        STALE_LABEL: ${{ inputs.stale-label }}
         EXCLUSION_LABELS: ${{ inputs.exclusion-labels }}
         COMMENT_TEMPLATE: ${{ inputs.comment-message }}
         MAX_ISSUES_PER_RUN: ${{ inputs.max-issues-per-run }}
@@ -125,6 +130,7 @@ runs:
             gracePeriodDisplay = `${gracePeriodDays} days`;
           }
 
+          const staleLabel = process.env.STALE_LABEL;
           const exclusionLabelsInput = process.env.EXCLUSION_LABELS;
           const commentTemplate = process.env.COMMENT_TEMPLATE;
           const dryRun = process.env.DRY_RUN === 'true';
@@ -135,20 +141,19 @@ runs:
             maxIssuesPerRun = DEFAULT_MAX_ISSUES;
           }
 
-          // Parse and validate exclusion labels
-          if (!exclusionLabelsInput || exclusionLabelsInput.trim() === '') {
-            console.error('Error: exclusion-labels input is empty. Cannot proceed.');
+          // Validate stale-label is non-empty (required trigger)
+          if (!staleLabel || staleLabel.trim() === '') {
+            console.error('Error: stale-label input is empty. Cannot proceed.');
             return;
           }
-          
-          const exclusionLabels = exclusionLabelsInput
-            .split(',')
-            .map(label => label.trim())
-            .filter(label => label.length > 0);
-          
-          if (exclusionLabels.length === 0) {
-            console.error('Error: No valid exclusion labels found after parsing. Cannot proceed.');
-            return;
+
+          // Parse exclusion labels (optional - can be empty)
+          let exclusionLabels = [];
+          if (exclusionLabelsInput && exclusionLabelsInput.trim() !== '') {
+            exclusionLabels = exclusionLabelsInput
+              .split(',')
+              .map(label => label.trim())
+              .filter(label => label.length > 0);
           }
 
           // Warn if comment template doesn't contain {assignee} placeholder
@@ -156,7 +161,8 @@ runs:
             console.warn('Warning: comment-message does not contain {assignee} placeholder. Unassigned users will not be mentioned.');
           }
 
-          console.log(`Configuration: grace-period=${gracePeriodDisplay}, exclusion-labels="${exclusionLabels.join(', ')}", max-issues=${maxIssuesPerRun || 'unlimited'}, dry-run=${dryRun}`);
+          const exclusionDisplay = exclusionLabels.length > 0 ? `"${exclusionLabels.join(', ')}"` : 'none';
+          console.log(`Configuration: grace-period=${gracePeriodDisplay}, stale-label="${staleLabel}", exclusion-labels=${exclusionDisplay}, max-issues=${maxIssuesPerRun || 'unlimited'}, dry-run=${dryRun}`);
 
           // Check if repository is archived
           const { data: repo } = await retry(() => github.rest.repos.get({
@@ -169,7 +175,22 @@ runs:
             return;
           }
 
-          // Check if at least one exclusion label exists in this repository
+          // Check if the stale label exists in this repository
+          try {
+            await retry(() => github.rest.issues.getLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: staleLabel
+            }));
+          } catch (error) {
+            if (error.status === 404) {
+              console.log(`Stale label "${staleLabel}" does not exist in this repository. Skipping.`);
+              return;
+            }
+            throw error;
+          }
+
+          // Validate exclusion labels exist (optional - warn if not found)
           let validExclusionLabels = [];
           for (const label of exclusionLabels) {
             try {
@@ -181,28 +202,27 @@ runs:
               validExclusionLabels.push(label);
             } catch (error) {
               if (error.status === 404) {
-                console.warn(`Label "${label}" does not exist in this repository, skipping this label.`);
+                console.warn(`Exclusion label "${label}" does not exist in this repository, ignoring.`);
               } else {
                 throw error;
               }
             }
           }
           
-          if (validExclusionLabels.length === 0) {
-            console.log('None of the exclusion labels exist in this repository. Skipping.');
-            return;
+          if (validExclusionLabels.length > 0) {
+            console.log(`Using ${validExclusionLabels.length} valid exclusion label(s): ${validExclusionLabels.join(', ')}`);
+          } else if (exclusionLabels.length > 0) {
+            console.log('None of the specified exclusion labels exist in this repository. Proceeding without exclusions.');
           }
-          
-          console.log(`Using ${validExclusionLabels.length} valid exclusion label(s): ${validExclusionLabels.join(', ')}`);
 
-
-          // Find all open issues in the repository
-          let allIssues = [];
+          // Find open issues with stale label (the trigger)
+          let issues = [];
           try {
-            allIssues = await retry(() => github.paginate(github.rest.issues.listForRepo, {
+            issues = await retry(() => github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
+              labels: staleLabel,
               per_page: 100
             }));
           } catch (error) {
@@ -210,19 +230,20 @@ runs:
             throw error;
           }
 
-          // Filter issues that have ANY of the exclusion labels
-          const issues = allIssues.filter(issue => {
-            const issueLabels = issue.labels.map(l => l.name);
-            return validExclusionLabels.some(label => issueLabels.includes(label));
-          });
-
-          console.log(`Found ${issues.length} open issues with any of the exclusion labels: ${validExclusionLabels.join(', ')}`);
+          console.log(`Found ${issues.length} open issues with stale label "${staleLabel}"`);
 
 
           // Apply max issues limit if set
           if (maxIssuesPerRun > 0 && issues.length > maxIssuesPerRun) {
             console.log(`Limiting to ${maxIssuesPerRun} issues per run (rate limit protection)`);
             issues = issues.slice(0, maxIssuesPerRun);
+          }
+
+          // Helper function to check if issue has any exclusion label
+          function hasExclusionLabel(issue) {
+            if (validExclusionLabels.length === 0) return false;
+            const issueLabels = issue.labels.map(l => l.name);
+            return validExclusionLabels.some(label => issueLabels.includes(label));
           }
 
           let processedCount = 0;
@@ -241,6 +262,16 @@ runs:
               // Skip if no assignees
               if (!issue.assignees || issue.assignees.length === 0) {
                 console.log(`Issue #${issue.number}: No assignees, skipping`);
+                skippedCount++;
+                continue;
+              }
+
+              // Skip if issue has any exclusion label (PREVENTS unassignment)
+              if (hasExclusionLabel(issue)) {
+                const matchedLabels = issue.labels
+                  .map(l => l.name)
+                  .filter(name => validExclusionLabels.includes(name));
+                console.log(`Issue #${issue.number}: Has exclusion label(s) [${matchedLabels.join(', ')}], skipping (protected from unassignment)`);
                 skippedCount++;
                 continue;
               }
@@ -302,14 +333,14 @@ runs:
 
               console.log(`Issue #${issue.number}: No open linked PR found, checking grace period...`);
 
-              // Find when any exclusion label was added (get the most recent one)
+              // Find when stale label was added (get the most recent one in case of re-labeling)
               const labelEvents = timelineEvents.filter(event =>
                 event.event === 'labeled' &&
-                validExclusionLabels.includes(event.label?.name)
+                event.label?.name === staleLabel
               );
 
               if (labelEvents.length === 0) {
-                console.log(`Issue #${issue.number}: Could not find any exclusion label event in timeline, skipping`);
+                console.log(`Issue #${issue.number}: Could not find stale label event in timeline, skipping`);
                 skippedCount++;
                 continue;
               }

--- a/.github/actions/stale-unassign/action.yml
+++ b/.github/actions/stale-unassign/action.yml
@@ -54,7 +54,7 @@ runs:
         github-token: ${{ inputs.github-token }}
         script: |
           // Read inputs from environment variables to prevent script injection
-          const DEFAULT_GRACE_PERIOD = 1;
+          const DEFAULT_GRACE_PERIOD = 7;
           const DEFAULT_MAX_ISSUES = 50;
 
           // Helper function for retrying API calls with exponential backoff
@@ -298,10 +298,23 @@ runs:
               // Check for OPEN linked PRs only (ignore closed/merged PRs) AND authored by assignee
               const hasOpenLinkedPR = timelineEvents.some(event => {
                 if (event.event === 'cross-referenced' && event.source?.issue?.pull_request) {
-                  // Check if PR is from the same repository
-                  const prRepoFullName = event.source.issue.repository?.full_name;
+                  // Check if PR is from the same repository by parsing repository_url
+                  const prRepoUrl = event.source.issue.repository_url;
                   const currentRepoFullName = `${context.repo.owner}/${context.repo.repo}`;
-                  const isSameRepo = prRepoFullName === currentRepoFullName;
+                  let isSameRepo = false;
+
+                  if (prRepoUrl) {
+                    // Extract owner/repo from URL (format: https://api.github.com/repos/owner/repo)
+                    const urlMatch = prRepoUrl.match(/\/repos\/([^\/]+\/[^\/]+)$/);
+                    if (urlMatch) {
+                      const prRepoFullName = urlMatch[1];
+                      isSameRepo = prRepoFullName === currentRepoFullName;
+                    } else {
+                      console.log(`Issue #${issue.number}: Could not parse repository_url: ${prRepoUrl}`);
+                    }
+                  } else {
+                    console.log(`Issue #${issue.number}: Missing repository_url for linked PR, treating as different repo`);
+                  }
 
                   // Only count OPEN PRs (ignore closed/merged)
                   const prState = event.source.issue.state;
@@ -317,6 +330,10 @@ runs:
 
                   if (isSameRepo && !isOpen) {
                     console.log(`Issue #${issue.number}: Found closed/merged PR, ignoring`);
+                  }
+
+                  if (!isSameRepo && prRepoUrl) {
+                    console.log(`Issue #${issue.number}: Found linked PR from different repository, ignoring`);
                   }
 
                   return isSameRepo && isOpen && isAuthoredByAssignee;

--- a/.github/actions/stale-unassign/action.yml
+++ b/.github/actions/stale-unassign/action.yml
@@ -218,13 +218,27 @@ runs:
           // Find open issues with stale label (the trigger)
           let issues = [];
           try {
-            issues = await retry(() => github.paginate(github.rest.issues.listForRepo, {
+            const limit = maxIssuesPerRun > 0 ? maxIssuesPerRun : Infinity;
+            
+            for await (const response of github.paginate.iterator(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
               labels: staleLabel,
               per_page: 100
-            }));
+            })) {
+              issues.push(...response.data);
+              
+              // Break early if we've reached the limit
+              if (issues.length >= limit) {
+                break;
+              }
+            }
+            
+            // Trim to exact limit if needed
+            if (issues.length > limit) {
+              issues = issues.slice(0, limit);
+            }
           } catch (error) {
             console.error(`Error fetching issues: ${error.message}`);
             throw error;
@@ -232,11 +246,8 @@ runs:
 
           console.log(`Found ${issues.length} open issues with stale label "${staleLabel}"`);
 
-
-          // Apply max issues limit if set
-          if (maxIssuesPerRun > 0 && issues.length > maxIssuesPerRun) {
-            console.log(`Limiting to ${maxIssuesPerRun} issues per run (rate limit protection)`);
-            issues = issues.slice(0, maxIssuesPerRun);
+          if (maxIssuesPerRun > 0 && issues.length === maxIssuesPerRun) {
+            console.log(`Limited to ${maxIssuesPerRun} issues per run (rate limit protection)`);
           }
 
           // Helper function to check if issue has any exclusion label

--- a/.github/actions/stale-unassign/action.yml
+++ b/.github/actions/stale-unassign/action.yml
@@ -69,8 +69,25 @@ runs:
                 if (isRateLimit && error.response && error.response.headers) {
                   const retryAfter = error.response.headers['retry-after'];
                   if (retryAfter) {
-                     // Retry-After is usually in seconds
-                     waitTime = Math.max(waitTime, parseInt(retryAfter, 10) * 1000);
+                     // Retry-After can be numeric (seconds) or HTTP-date string
+                     const numericValue = parseInt(retryAfter, 10);
+                     let retryAfterMs;
+                     
+                     if (!isNaN(numericValue) && String(numericValue) === retryAfter.trim()) {
+                       // Numeric value in seconds
+                       retryAfterMs = numericValue * 1000;
+                     } else {
+                       // HTTP-date string - parse and compute milliseconds from now
+                       const retryDate = Date.parse(retryAfter);
+                       if (!isNaN(retryDate)) {
+                         retryAfterMs = Math.max(0, retryDate - Date.now());
+                       }
+                     }
+                     
+                     // Only update waitTime if we got a valid number
+                     if (retryAfterMs !== undefined && !isNaN(retryAfterMs)) {
+                       waitTime = Math.max(waitTime, retryAfterMs);
+                     }
                   }
                 }
 

--- a/.github/actions/stale-unassign/action.yml
+++ b/.github/actions/stale-unassign/action.yml
@@ -366,6 +366,14 @@ runs:
               labelEvents.sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
               const latestLabelEvent = labelEvents[labelEvents.length - 1];
               const labelAddedDate = new Date(latestLabelEvent.created_at);
+
+              // Validate that the date is valid
+              if (isNaN(labelAddedDate.getTime())) {
+                console.log(`Issue #${issue.number}: Invalid created_at date in label event (${latestLabelEvent.created_at}), skipping`);
+                skippedCount++;
+                continue;
+              }
+
               const now = new Date();
               const daysSinceLabel = (now - labelAddedDate) / (1000 * 60 * 60 * 24);
 

--- a/.github/actions/stale-unassign/action.yml
+++ b/.github/actions/stale-unassign/action.yml
@@ -1,0 +1,349 @@
+name: 'Stale Issue Unassigner'
+description: 'Automatically unassigns stale issues after a grace period'
+author: 'PalisadoesFoundation'
+
+inputs:
+  grace-period-days:
+    description: 'Days after label application before unassignment (for production)'
+    required: false
+    default: '7'
+  grace-period-minutes:
+    description: 'Minutes after label application before unassignment (for testing - overrides days if > 0)'
+    required: false
+    default: '0'
+  dry-run:
+    description: 'Run without making changes. Logs intended actions.'
+    required: false
+    default: 'false'
+  stale-label:
+    description: 'Label that marks issues as stale'
+    required: false
+    default: 'no-issue-activity'
+  comment-message:
+    description: 'Comment posted when assignee is removed. Use {assignee} placeholder for username.'
+    required: false
+    default: |
+      Hi {assignee}, this issue has been unassigned due to inactivity after being marked as stale.
+      Feel free to reassign yourself if you plan to continue working on it.
+  max-issues-per-run:
+    description: 'Maximum number of issues to process per run (0 for unlimited). Helps avoid rate limiting.'
+    required: false
+    default: '50'
+  github-token:
+    description: 'GitHub token for API calls'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Unassign stale issues
+      uses: actions/github-script@v7
+      env:
+        GRACE_PERIOD_DAYS: ${{ inputs.grace-period-days }}
+        GRACE_PERIOD_MINUTES: ${{ inputs.grace-period-minutes }}
+        STALE_LABEL: ${{ inputs.stale-label }}
+        COMMENT_TEMPLATE: ${{ inputs.comment-message }}
+        MAX_ISSUES_PER_RUN: ${{ inputs.max-issues-per-run }}
+        DRY_RUN: ${{ inputs.dry-run }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          // Read inputs from environment variables to prevent script injection
+          const DEFAULT_GRACE_PERIOD = 1;
+          const DEFAULT_MAX_ISSUES = 50;
+
+          // Helper function for retrying API calls with exponential backoff
+          async function retry(fn, retries = 3, delay = 1000) {
+            try {
+              return await fn();
+            } catch (error) {
+              const status = error.status || 0;
+              const isRateLimit = status === 429 || status === 403;
+              const isServerErr = status >= 500;
+              const isNetworkErr = error.message && error.message.includes('network');
+
+              if (retries > 0 && (isServerErr || isNetworkErr || isRateLimit)) {
+                let waitTime = delay;
+
+                // Check Retry-After header
+                if (isRateLimit && error.response && error.response.headers) {
+                  const retryAfter = error.response.headers['retry-after'];
+                  if (retryAfter) {
+                     // Retry-After is usually in seconds
+                     waitTime = Math.max(waitTime, parseInt(retryAfter, 10) * 1000);
+                  }
+                }
+
+                console.warn(`API call failed (${error.message}). Retrying in ${waitTime}ms...`);
+                await new Promise(r => setTimeout(r, waitTime));
+                return retry(fn, retries - 1, delay * 2);
+              }
+              throw error;
+            }
+          }
+
+          // Parse grace period - minutes takes priority over days for testing
+          let gracePeriodMinutes = parseInt(process.env.GRACE_PERIOD_MINUTES, 10);
+          let gracePeriodDays = parseInt(process.env.GRACE_PERIOD_DAYS, 10);
+          
+          // Validate inputs
+          if (!Number.isFinite(gracePeriodMinutes) || gracePeriodMinutes < 0) {
+            gracePeriodMinutes = 0;
+          }
+          if (!Number.isFinite(gracePeriodDays) || gracePeriodDays < 0) {
+            gracePeriodDays = DEFAULT_GRACE_PERIOD;
+          }
+          
+          // Calculate grace period in days (for display and calculation)
+          let gracePeriodInDays;
+          let gracePeriodDisplay;
+          
+          if (gracePeriodMinutes > 0) {
+            // Minutes takes priority (for testing)
+            gracePeriodInDays = gracePeriodMinutes / (60 * 24);
+            gracePeriodDisplay = `${gracePeriodMinutes} minutes`;
+          } else {
+            // Use days (for production)
+            gracePeriodInDays = gracePeriodDays;
+            gracePeriodDisplay = `${gracePeriodDays} days`;
+          }
+
+          const staleLabel = process.env.STALE_LABEL;
+          const commentTemplate = process.env.COMMENT_TEMPLATE;
+          const dryRun = process.env.DRY_RUN === 'true';
+
+          let maxIssuesPerRun = parseInt(process.env.MAX_ISSUES_PER_RUN, 10);
+          if (!Number.isFinite(maxIssuesPerRun) || maxIssuesPerRun < 0) {
+            console.warn(`Invalid max-issues-per-run "${process.env.MAX_ISSUES_PER_RUN}", using default: ${DEFAULT_MAX_ISSUES}`);
+            maxIssuesPerRun = DEFAULT_MAX_ISSUES;
+          }
+
+          // Validate stale-label is non-empty
+          if (!staleLabel || staleLabel.trim() === '') {
+            console.error('Error: stale-label input is empty. Cannot proceed.');
+            return;
+          }
+
+          // Warn if comment template doesn't contain {assignee} placeholder
+          if (!commentTemplate.includes('{assignee}')) {
+            console.warn('Warning: comment-message does not contain {assignee} placeholder. Unassigned users will not be mentioned.');
+          }
+
+          console.log(`Configuration: grace-period=${gracePeriodDisplay}, stale-label="${staleLabel}", max-issues=${maxIssuesPerRun || 'unlimited'}, dry-run=${dryRun}`);
+
+          // Check if repository is archived
+          const { data: repo } = await retry(() => github.rest.repos.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo
+          }));
+
+          if (repo.archived) {
+            console.log('Repository is archived. Skipping.');
+            return;
+          }
+
+          // Check if the stale label exists in this repository
+          try {
+            await retry(() => github.rest.issues.getLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: staleLabel
+            }));
+          } catch (error) {
+            if (error.status === 404) {
+              console.log(`Label "${staleLabel}" does not exist in this repository. Skipping.`);
+              return;
+            }
+            throw error;
+          }
+
+          // Find open issues with stale label
+          let issues = [];
+          try {
+            issues = await retry(() => github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: staleLabel,
+              per_page: 100
+            }));
+          } catch (error) {
+            console.error(`Error fetching issues: ${error.message}`);
+            throw error;
+          }
+
+          console.log(`Found ${issues.length} open issues with "${staleLabel}" label`);
+
+          // Apply max issues limit if set
+          if (maxIssuesPerRun > 0 && issues.length > maxIssuesPerRun) {
+            console.log(`Limiting to ${maxIssuesPerRun} issues per run (rate limit protection)`);
+            issues = issues.slice(0, maxIssuesPerRun);
+          }
+
+          let processedCount = 0;
+          let skippedCount = 0;
+          let errorCount = 0;
+
+          for (const issue of issues) {
+            try {
+              // Skip pull requests (they appear in issues API too)
+              if (issue.pull_request) {
+                console.log(`Issue #${issue.number}: Is a pull request, skipping`);
+                skippedCount++;
+                continue;
+              }
+
+              // Skip if no assignees
+              if (!issue.assignees || issue.assignees.length === 0) {
+                console.log(`Issue #${issue.number}: No assignees, skipping`);
+                skippedCount++;
+                continue;
+              }
+
+              const assigneeLogins = issue.assignees.map(a => a.login);
+              const assigneeCount = issue.assignees.length;
+              console.log(`Issue #${issue.number}: Has ${assigneeCount} assignee(s)`);
+
+              // Check for linked PRs in the same repository using timeline events
+              let timelineEvents = [];
+              try {
+                timelineEvents = await retry(() => github.paginate(github.rest.issues.listEventsForTimeline, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  per_page: 100
+                }));
+              } catch (error) {
+                console.error(`Issue #${issue.number}: Error fetching timeline: ${error.message}`);
+                skippedCount++;
+                continue;
+              }
+
+              // Check for OPEN linked PRs only (ignore closed/merged PRs) AND authored by assignee
+              const hasOpenLinkedPR = timelineEvents.some(event => {
+                if (event.event === 'cross-referenced' && event.source?.issue?.pull_request) {
+                  // Check if PR is from the same repository
+                  const prRepoFullName = event.source.issue.repository?.full_name;
+                  const currentRepoFullName = `${context.repo.owner}/${context.repo.repo}`;
+                  const isSameRepo = prRepoFullName === currentRepoFullName;
+
+                  // Only count OPEN PRs (ignore closed/merged)
+                  const prState = event.source.issue.state;
+                  const isOpen = prState === 'open';
+
+                  // Check if PR author is one of the assignees
+                  const prAuthor = event.source.issue.user?.login;
+                  const isAuthoredByAssignee = assigneeLogins.includes(prAuthor);
+
+                  if (isSameRepo && isOpen && !isAuthoredByAssignee) {
+                    console.log(`Issue #${issue.number}: Found open PR by different author (@${prAuthor}), ignoring (must be by assignee)`);
+                  }
+
+                  if (isSameRepo && !isOpen) {
+                    console.log(`Issue #${issue.number}: Found closed/merged PR, ignoring`);
+                  }
+
+                  return isSameRepo && isOpen && isAuthoredByAssignee;
+                }
+                return false;
+              });
+
+              // Skip if there IS an OPEN linked PR (contributor is actively working)
+              if (hasOpenLinkedPR) {
+                console.log(`Issue #${issue.number}: Has open linked PR in same repo, skipping (contributor is working)`);
+                skippedCount++;
+                continue;
+              }
+
+              console.log(`Issue #${issue.number}: No open linked PR found, checking grace period...`);
+
+              // Find when stale label was added (get the most recent one in case of re-labeling)
+              const labelEvents = timelineEvents.filter(event =>
+                event.event === 'labeled' &&
+                event.label?.name === staleLabel
+              );
+
+              if (labelEvents.length === 0) {
+                console.log(`Issue #${issue.number}: Could not find label event in timeline, skipping`);
+                skippedCount++;
+                continue;
+              }
+
+              // Sort by date and use the most recent label event
+              labelEvents.sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+              const latestLabelEvent = labelEvents[labelEvents.length - 1];
+              const labelAddedDate = new Date(latestLabelEvent.created_at);
+              const now = new Date();
+              const daysSinceLabel = (now - labelAddedDate) / (1000 * 60 * 60 * 24);
+
+              if (daysSinceLabel < gracePeriodInDays) {
+                console.log(`Issue #${issue.number}: Grace period not exceeded (${daysSinceLabel.toFixed(1)} days / ${gracePeriodDisplay}), skipping`);
+                skippedCount++;
+                continue;
+              }
+
+              console.log(`Issue #${issue.number}: Grace period exceeded (${daysSinceLabel.toFixed(1)} days > ${gracePeriodDisplay}). Processing ${assigneeCount} assignee(s)...`);
+
+
+
+              // Remove all assignees at once (more efficient)
+              try {
+                if (dryRun) {
+                  console.log(`[DRY RUN] Would remove assignees: ${assigneeLogins.join(', ')} from issue #${issue.number}`);
+                } else {
+                  await retry(() => github.rest.issues.removeAssignees({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    assignees: assigneeLogins
+                  }));
+                }
+              } catch (error) {
+                console.error(`Issue #${issue.number}: Error removing assignees: ${error.message}`);
+                errorCount++;
+                skippedCount++;
+                continue;
+              }
+
+              // Post a single comment addressing all unassigned users
+              const assigneeMentions = assigneeLogins.map(login => `@${login}`).join(', ');
+              const comment = commentTemplate.replace(/\{assignee\}/g, assigneeMentions);
+
+              try {
+                if (dryRun) {
+                  console.log(`[DRY RUN] Would post comment to issue #${issue.number}: "${comment.replace(/\n/g, '\\n')}"`);
+                } else {
+                  await retry(() => github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    body: comment
+                  }));
+                }
+              } catch (error) {
+                console.error(`Issue #${issue.number}: Error posting comment: ${error.message}`);
+                // Don't fail the whole workflow for a comment error
+              }
+
+              console.log(`Issue #${issue.number}: Successfully processed ${assigneeLogins.join(', ')}`);
+              processedCount++;
+
+            } catch (error) {
+              console.error(`Issue #${issue.number}: Unexpected error: ${error.message}`);
+              errorCount++;
+              skippedCount++;
+            }
+          }
+
+          console.log(`\nSummary: Processed ${processedCount}, Skipped ${skippedCount}, Errors ${errorCount}`);
+
+          // Post job summary
+          await core.summary
+            .addHeading('Stale Issue Unassignment Report')
+            .addTable([
+              ['Metric', 'Count'],
+              ['Processed', processedCount.toString()],
+              ['Skipped', skippedCount.toString()],
+              ['Errors', errorCount.toString()]
+            ])
+            .write();

--- a/.github/workflows/stale-unassign.yml
+++ b/.github/workflows/stale-unassign.yml
@@ -46,8 +46,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           grace-period-minutes: ${{ github.event.inputs.grace-period-minutes || '0' }}
           grace-period-days: ${{ github.event.inputs.grace-period-days || '7' }}
-          # Uncomment to customize the exclusion labels (comma-separated):
-          # exclusion-labels: 'no-issue-activity,on-hold,waiting-for-maintainer'
+          # stale-label: 'no-issue-activity'  # Label that triggers unassignment (default: no-issue-activity)
+          # Uncomment to specify labels that PREVENT unassignment (comma-separated):
+          # exclusion-labels: 'waiting-for-maintainer,blocked,on-hold'
           # Uncomment to customize the comment message:
           # comment-message: |
           #   Hi {assignee}, this issue has been unassigned due to inactivity.

--- a/.github/workflows/stale-unassign.yml
+++ b/.github/workflows/stale-unassign.yml
@@ -1,0 +1,52 @@
+##############################################################################
+##############################################################################
+#
+# NOTE!
+#
+# Please read the README.md file in this directory that defines what should
+# be placed in this file
+#
+##############################################################################
+##############################################################################
+
+name: Auto-unassign Stale Issues
+
+on:
+  schedule:
+    # Run daily at midnight UTC
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+    # Manual trigger for testing
+    inputs:
+      grace-period-minutes:
+        description: 'Grace period in minutes (for testing - takes priority over days if > 0)'
+        required: false
+        default: '0'
+      grace-period-days:
+        description: 'Grace period in days (for production - used when minutes is 0)'
+        required: false
+        default: '7'
+
+permissions:
+  issues: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  unassign-stale:
+    name: Unassign Stale Issues
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run stale unassign action
+        uses: ./.github/actions/stale-unassign
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          grace-period-minutes: ${{ github.event.inputs.grace-period-minutes || '0' }}
+          grace-period-days: ${{ github.event.inputs.grace-period-days || '7' }}
+          # Uncomment to customize the comment message:
+          # comment-message: |
+          #   Hi @{assignee}, this issue has been unassigned due to inactivity.
+          #   Feel free to reassign yourself if you plan to continue.

--- a/.github/workflows/stale-unassign.yml
+++ b/.github/workflows/stale-unassign.yml
@@ -48,5 +48,5 @@ jobs:
           grace-period-days: ${{ github.event.inputs.grace-period-days || '7' }}
           # Uncomment to customize the comment message:
           # comment-message: |
-          #   Hi @{assignee}, this issue has been unassigned due to inactivity.
+          #   Hi {assignee}, this issue has been unassigned due to inactivity.
           #   Feel free to reassign yourself if you plan to continue.

--- a/.github/workflows/stale-unassign.yml
+++ b/.github/workflows/stale-unassign.yml
@@ -46,6 +46,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           grace-period-minutes: ${{ github.event.inputs.grace-period-minutes || '0' }}
           grace-period-days: ${{ github.event.inputs.grace-period-days || '7' }}
+          # Uncomment to customize the exclusion labels (comma-separated):
+          # exclusion-labels: 'no-issue-activity,on-hold,waiting-for-maintainer'
           # Uncomment to customize the comment message:
           # comment-message: |
           #   Hi {assignee}, this issue has been unassigned due to inactivity.


### PR DESCRIPTION
- Automatically unassigns stale issues after grace period
- Checks for open PRs authored by assignee
- Supports minutes (testing) and days (production)
- Tested with 5-minute grace period in talawa-admin
- Includes retry logic and dry-run capability

Resolves #24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated stale-issue unassignment workflow (runs nightly or manually). Issues labeled "stale" that exceed a configurable grace period (minutes or days) can be auto-unassigned (supports dry-run), optionally receive templated comments, and are processed up to a per-run limit. Workflow skips archived repos, missing labels, PRs, issues with open linked PRs, and produces a summary of processed, skipped, and error counts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->