### PR TITLE
ci: add reusable workflow to comment on first-time PRs

### DIFF
--- a/.github/workflows/pull-request-comment.yml
+++ b/.github/workflows/pull-request-comment.yml
@@ -1,0 +1,41 @@
+name: Comment on First PR
+
+on:
+  workflow_call:
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  comment-on-first-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              return;
+            }
+
+            const author = pr.user.login;
+
+            const pulls = await github.paginate(
+              github.rest.pulls.list,
+              { owner, repo, state: "closed" }
+            );
+
+            const hasMergedBefore = pulls.some(
+              p => p.user.login === author && p.merged_at
+            );
+
+            if (!hasMergedBefore) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pr.number,
+                body: "👋 Thanks for opening your first pull request! A maintainer will review it shortly."
+              });
+            }


### PR DESCRIPTION
### Summary

Adds a reusable GitHub Actions workflow that comments on a contributor’s first pull request if they have no previously merged PRs in the repository. This workflow is designed to live in the `.github` repo and be referenced from individual project PR pipelines (for example, `talawa-admin/.github/workflows/pull-request.yml`).

### Motivation

Multiple PalisadoesFoundation repositories require consistent contributor onboarding behavior. Centralizing this logic in the `.github` repository avoids duplication and allows repositories to opt in by referencing a single, maintained workflow.

### Implementation Details

- Introduces `.github/workflows/pull-request-comment.yml` as a reusable `workflow_call` workflow
- Uses `actions/github-script` to detect whether the PR author has any previously merged pull requests
- Posts a single welcome comment only for first-time contributors
- Does not trigger on its own and must be explicitly referenced by consuming repositories

### Follow-up

After this is merged, a small follow-up PR will reference this workflow from `talawa-admin`’s `pull-request.yml`.

No breaking changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflow to recognize and welcome first-time pull request contributors with a thank-you message and review acknowledgment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->