### PR TITLE
ci: add reusable workflow to comment on first-time PRs

### DIFF
--- a/.github/workflows/pull-request-comment.yml
+++ b/.github/workflows/pull-request-comment.yml
@@ -1,0 +1,41 @@
+name: Comment on First PR
+
+on:
+  workflow_call:
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  comment-on-first-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              return;
+            }
+
+            const author = pr.user.login;
+
+            const pulls = await github.paginate(
+              github.rest.pulls.list,
+              { owner, repo, state: "closed" }
+            );
+
+            const hasMergedBefore = pulls.some(
+              p => p.user.login === author && p.merged_at
+            );
+
+            if (!hasMergedBefore) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pr.number,
+                body: "👋 Thanks for opening your first pull request! A maintainer will review it shortly."
+              });
+            }


### PR DESCRIPTION
**What kind of change does this PR introduce?**  
CI/CD enhancement (GitHub Actions)

**Issue Number:**  
Fixes #42

**Snapshots/Videos:**  
N/A

**If relevant, did you update the documentation?**  
N/A

**Summary**  
Adds a reusable GitHub Actions workflow that comments on a contributor’s first pull request if they have no previously merged PRs in the repository. This workflow is designed to live in the `.github` repository and be referenced by other PalisadoesFoundation repositories.

**Does this PR introduce a breaking change?**  
No

## Checklist

### CodeRabbit AI Review
- [x] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [x] I have implemented or provided justification for each non-critical suggestion
- [x] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass

**Other information**  
Introduces `.github/workflows/pull-request-comment.yml` as a reusable `workflow_call` workflow. No existing files were modified. Consuming repositories must explicitly reference this workflow from their PR pipelines.

**Have you read the contributing guide?**  
Yes
